### PR TITLE
ajout gmap_cheap

### DIFF
--- a/HpFront/src/App.css
+++ b/HpFront/src/App.css
@@ -7,7 +7,8 @@
     --color_text: #254441;
     --color_melon: #f8d3a3;
     --color_melon_light: #f8d3a3a4;
-    --color_green: #43AA8B;
+    --color_green: #43aa8b;
+    --color_green_light: #43aa8b86;
     --color_grey: #bcb8b1;
 }
 

--- a/HpFront/src/components/Gmap_cheap/GmapCheap.css
+++ b/HpFront/src/components/Gmap_cheap/GmapCheap.css
@@ -1,0 +1,13 @@
+.gmapcheap {
+    padding: 20px;
+    display: flex;
+    justify-content: center;
+    background: var(--color_green_light);
+}
+
+.gmapcheap img {
+    max-width: 100%;
+    border: 6px solid var(--color_green_light);
+    border-radius: 12px;
+    box-shadow: var(--color_green_light) 0px 4px 16px, var(--color_green_light) 0px 8px 32px;
+}

--- a/HpFront/src/components/Gmap_cheap/GmapCheap.js
+++ b/HpFront/src/components/Gmap_cheap/GmapCheap.js
@@ -1,0 +1,14 @@
+import './GmapCheap.css'
+import cheap_map from '../../assets/img/google_map_cheap.png';
+
+const GmapCheap = () => {
+    return (
+        <div className="gmapcheap">
+            <a href="https://goo.gl/maps/zbSxBn2TP3t661XZA" target="_blank">
+                <img src={cheap_map} alt="google map image" />
+            </a>
+        </div>
+    );
+}
+
+export default GmapCheap;

--- a/HpFront/src/components/RoutesHairPrestige/RoutesHairPrestige.js
+++ b/HpFront/src/components/RoutesHairPrestige/RoutesHairPrestige.js
@@ -4,15 +4,17 @@ import Conseils from '../../pages/Conseils/Conseils';
 import Cgv from '../../components/Cgv/Cgv';
 import Photos from "../../pages/Photos/Photos";
 import Prestations from '../../pages/Prestations/Prestations';
+import Contact from '../../pages/Contact/Contact';
 
 const RoutesHairPrestige = () => {
     return (
         <Routes>
             <Route path="/" element={<Home />} />
             <Route path="/conseils" element={<Conseils />} />
-            <Route path="/cgv" element={<Cgv />} />
-            <Route path="/photos" element={<Photos />} />
+            <Route path="/contact" element={<Contact />} />
             <Route path="/prestations" element={<Prestations/>} />
+            <Route path="/photos" element={<Photos />} />
+            <Route path="/cgv" element={<Cgv />} />
         </Routes>
     );
 }

--- a/HpFront/src/pages/Contact/Contact.js
+++ b/HpFront/src/pages/Contact/Contact.js
@@ -1,0 +1,11 @@
+import GmapCheap from "../../components/Gmap_cheap/GmapCheap";
+
+const Contact = () => {
+    return ( 
+        <div className="contact">
+            <GmapCheap />
+        </div>
+     );
+}
+ 
+export default Contact;


### PR DESCRIPTION
Pour intégrer google map directement sur un site faut utiliser une clé API (fournie par google) qui oblige de donner ses coordonnées bancaires (parce qu'il se font du biz après un certain nombre de requêtes)

Du coup, Toujours dans l'esprit d'ajouter de la valeur à son salon sans que ta sœur ai à faire quoi que ce soit, j'ai pris une image de sa localisation que j'ai utilisé comme balise qui redirige vers la page google map, comme ça l'effet est moins beau, mais gratuit sans soucis \o/